### PR TITLE
Support excluding non physical and wireless network adapters to deal with MAC randomization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,7 @@ Custom components can be built by implementing `IDeviceIdComponent`. There is al
 
 #### Dealing with MAC Address randomization and virtual network adapters
 
-Non physcial network adapters like VPN connections tend not to have fixed MAC addresses. For wireless (802.11 based) adapters hardware
-(MAC) address randomization is frequently applied to avoid tracking with many modern operating systems support this out of the box. This
-makes wireless network adapters bad candidates for device indentification.
+Non physical network adapters like VPN connections tend not to have fixed MAC addresses. For wireless (802.11 based) adapters hardware (MAC) address randomization is frequently applied to avoid tracking with many modern operating systems support this out of the box. This makes wireless network adapters bad candidates for device identification.
 
 Use `AddMacAddress(true, true)` to exclude both virtual and wireless network adapters.
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,14 @@ The following extension methods are available out of the box to suit some common
 
 Custom components can be built by implementing `IDeviceIdComponent`. There is also a simple `DeviceIdComponent` class that allows you to specify an arbitrary component value to use, and a `WmiDeviceIdComponent` class that uses a specified WMI property (example: `new WmiDeviceIdComponent("MACAddress", "Win32_NetworkAdapterConfiguration", "MACAddress"`).
 
+#### Dealing with MAC Address randomization and virtual network adapters
+
+Non physcial network adapters like VPN connections tend not to have fixed MAC addresses. For wireless (802.11 based) adapters hardware
+(MAC) address randomization is frequently applied to avoid tracking with many modern operating systems support this out of the box. This
+makes wireless network adapters bad candidates for device indentification.
+
+Use `AddMacAddress(true, true)` to exclude both virtual and wireless network adapters.
+
 ### Controlling how the device identifier is formatted
 
 Use the `UseFormatter` method to set the formatter.

--- a/src/DeviceId/Components/NetworkAdapterDeviceIdComponent.cs
+++ b/src/DeviceId/Components/NetworkAdapterDeviceIdComponent.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+
+namespace DeviceId.Components
+{
+    /// <summary>
+    /// An implementation of <see cref="IDeviceIdComponent"/> that retrieves data from installed network adapaters.
+    /// </summary>
+    /// <remarks>Based on Win32_NetworkAdapter WMI class or using the CIMv2 based MSFT_NetAdapter
+    /// WMI class (Windows 8 and up only).
+    /// Optionally filters out non physical network adapters (not related to virtual machines) and wireless adapters.</remarks>
+    public class NetworkAdapterDeviceIdComponent : IDeviceIdComponent
+    {
+
+        private readonly bool _excludeNonPhysical;
+
+        private readonly bool _excludeWireless;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkAdapterDeviceIdComponent"/> class.
+        /// </summary>
+        /// <param name="excludeNonPhysical">Indicates if non physcial adapters should be excluded.</param>
+        /// <param name="excludeWireless">Indicates if wireless adapters should be excluded.</param>
+        /// <remarks>Non physical adapters are unlikely to have a stable MAC address. For wireless adapters MAC randomization is a frequently offered function, making it unsuitable for identifying a device.</remarks>
+        public NetworkAdapterDeviceIdComponent(bool excludeNonPhysical, bool excludeWireless)
+        {
+            _excludeNonPhysical = excludeNonPhysical;
+            _excludeWireless = excludeWireless;
+        }
+
+        /// <summary>
+        /// Gets the name of the component.
+        /// </summary>
+        public string Name => "MACAddress";
+
+        /// <summary>
+        /// Retrieves the MAC 
+        /// </summary>
+        /// <returns></returns>
+        internal List<string> GetMacAddressesUsingWmi()
+        {
+            List<string> values = new List<string>();
+
+            using (var mc = new ManagementClass("Win32_NetworkAdapter"))
+            {
+                foreach (var adapter in mc.GetInstances())
+                {
+                    try
+                    {
+
+                        bool isPhysical = (bool)adapter["PhysicalAdapter"];
+                        var adapterType = adapter["AdapterType"] as string;
+
+                        // Skip non physcial adapters if instructed to do so.
+                        if (_excludeNonPhysical && !isPhysical)
+                            continue;
+
+                        // Add the MAC address to the list of values.
+                        string value = adapter["MACAddress"] as string;
+                        if (value != null)
+                        {
+                            values.Add(value);
+                        }
+                    }
+                    finally
+                    {
+                        adapter.Dispose();
+                    }
+                }
+            }
+
+            return values;
+        }
+
+        private enum NdisPhysicalMedium
+        {
+            Native802_11 = 9
+        }
+
+        /// <summary>
+        /// Retrieves the MAC Addresses using the CIMv2 based MSFT_NetAdapter interface (Windows 8 and up).
+        /// </summary>
+        /// <returns></returns>
+        internal List<string> GetMacAddressesUsingCimV2()
+        {
+            List<string> values = new List<string>();
+
+            using (var mc = new ManagementClass("root/StandardCimv2", "MSFT_NetAdapter", new ObjectGetOptions { }))
+            {
+                foreach (var adapter in mc.GetInstances())
+                {
+                    try
+                    {
+
+                        bool isPhysical = (bool)adapter["ConnectorPresent"];
+                        var ndisMedium = (uint)adapter["NdisPhysicalMedium"];
+
+                        // Skip non physcial adapters if instructed to do so.
+                        if (_excludeNonPhysical && !isPhysical)
+                            continue;
+
+                        // Skip wireless adapters if instructed to do so.
+                        if (_excludeWireless && ndisMedium == 9)
+                            continue;
+
+                        // Add the MAC address to the list of values.
+                        var value = adapter["PermanentAddress"] as string;
+                        if (value != null)
+                        {
+                            value = FormatMacAddress(value);
+                            values.Add(value);
+                        }
+                    }
+                    finally
+                    {
+                        adapter.Dispose();
+                    }
+                }
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Gets the component value.
+        /// </summary>
+        /// <returns>The component value.</returns>
+        public string GetValue()
+        {
+
+            List<string> values;
+
+            try
+            {
+
+                // First attempt to retrieve the addresses using the CIMv2 interface.
+                values = GetMacAddressesUsingCimV2();
+            }
+            catch (ManagementException ex)
+            {
+
+                // In case we are notified of an invalid namespace, attempt to lookup the adapters using WMI.
+                // Could avoid this catch by manually checking for the CIMv2 namespace.
+                if (ex.ErrorCode == ManagementStatus.InvalidNamespace)
+                    values = GetMacAddressesUsingWmi();
+                else
+                    throw;
+            }
+
+            return String.Join(",", values);
+        }
+
+        internal static string FormatMacAddress(string input)
+        {
+
+            // Check if this can be a hex formatted EUI-48 or EUI-64 identifier.
+            if (input.Length != 12 && input.Length != 16)
+                return input;
+
+            // Chop up input in 2 character chunks.
+            var partSize = 2;
+            var parts = Enumerable.Range(0, input.Length / partSize)
+                .Select(i => input.Substring(i * partSize, partSize));
+
+            // Put the parts in the AA:BB:CC format.
+            var result = string.Join(":", parts);
+            return result;
+        }
+    }
+}

--- a/src/DeviceId/Components/NetworkAdapterDeviceIdComponent.cs
+++ b/src/DeviceId/Components/NetworkAdapterDeviceIdComponent.cs
@@ -36,7 +36,7 @@ namespace DeviceId.Components
         public string Name => "MACAddress";
 
         /// <summary>
-        /// Retrieves the MAC 
+        /// Retrieves the MAC using the (old) Win32_NetworkAdapter WMI class.
         /// </summary>
         /// <returns></returns>
         internal List<string> GetMacAddressesUsingWmi()
@@ -109,6 +109,10 @@ namespace DeviceId.Components
                         var value = adapter["PermanentAddress"] as string;
                         if (value != null)
                         {
+
+                            // Ensure the hardware addresses are formatted as MAC addresses if possible.
+                            // This is a discrepancy between the MSFT_NetAdapter and Win32_NetworkAdapter
+                            // interfaces.
                             value = FormatMacAddress(value);
                             values.Add(value);
                         }

--- a/src/DeviceId/DeviceIdBuilderExtensions.cs
+++ b/src/DeviceId/DeviceIdBuilderExtensions.cs
@@ -73,6 +73,18 @@ namespace DeviceId
         }
 
         /// <summary>
+        /// Adds the MAC address to the device identifier, optionally excluding
+        /// </summary>
+        /// <param name="builder">The <see cref="DeviceIdBuilder"/> to add the component to.</param>
+        /// <param name="excludeNonPhysical">Indicates if non physcial adapters should be excluded.</param>
+        /// <param name="excludeWireless">Indicates if wireless adapters should be excluded.</param>
+        /// <returns>The <see cref="DeviceIdBuilder"/> instance.</returns>
+        public static DeviceIdBuilder AddMacAddress(this DeviceIdBuilder builder, bool excludeNonPhysical = false, bool excludeWireless = false)
+        {
+            return builder.AddComponent(new NetworkAdapterDeviceIdComponent(excludeNonPhysical, excludeWireless));
+        }
+
+        /// <summary>
         /// Adds the processor ID to the device identifier.
         /// </summary>
         /// <param name="builder">The <see cref="DeviceIdBuilder"/> to add the component to.</param>

--- a/src/DeviceId/InternalsVisibleTo.cs
+++ b/src/DeviceId/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("DeviceId.Tests")]

--- a/test/DeviceId.Tests/Components/NetworkAdapterDeviceIdComponentTests.cs
+++ b/test/DeviceId.Tests/Components/NetworkAdapterDeviceIdComponentTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+using DeviceId.Components;
+
+namespace DeviceId.Tests.Components
+{
+    public class NetworkAdapterDeviceIdComponentTests
+    {
+        [Fact]
+        public void GetValue()
+        {
+
+            var component = new NetworkAdapterDeviceIdComponent(true, false);
+            component.GetValue();
+        }
+
+        [Fact]
+        public void FormatMac_NonMac()
+        {
+
+            var input = "Try me";
+            var result = NetworkAdapterDeviceIdComponent.FormatMacAddress(input);
+            result.ShouldBeEquivalentTo(input, "Non MAC addresses are not formatted");
+        }
+
+        [Fact]
+        public void FormatMac_48BitMac()
+        {
+
+            var input = "AABBCCDDEEFF";
+            var result = NetworkAdapterDeviceIdComponent.FormatMacAddress(input);
+            result.ShouldBeEquivalentTo("AA:BB:CC:DD:EE:FF", "MAC address should be formatted");
+        }
+
+        [Fact]
+        public void FormatMac_64BitMac()
+        {
+
+            var input = "AABBCCDDEEFF0011";
+            var result = NetworkAdapterDeviceIdComponent.FormatMacAddress(input);
+            result.ShouldBeEquivalentTo("AA:BB:CC:DD:EE:FF:00:11", "MAC address should be formatted");
+        }
+    }
+}


### PR DESCRIPTION
Non physical network adapters like VPN connections tend not to have fixed MAC addresses. For wireless (802.11 based) adapters hardware (MAC) address randomization is frequently applied to avoid tracking with many modern operating systems support this out of the box. This makes wireless network adapters bad candidates for device identification.

To this end I implemented the `NetworkAdapterDeviceIdComponent` class and a new `AddMacAddress` extension method. I had to work some magic because prior to Windows 8 it is pretty difficult to figure out if a network adapter is wireless or not using WMI.

Basic unit tests are included but are limited as the outcome ultimately depends on the hardware the test is running on.