### PR TITLE
Add support for Linux

### DIFF
--- a/src/DeviceId/Components/FileDeviceIdComponent.cs
+++ b/src/DeviceId/Components/FileDeviceIdComponent.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DeviceId.Components
+{
+    /// <summary>
+    /// An implementation of <see cref="IDeviceIdComponent"/> that retrieves its value from a file.
+    /// </summary>
+    public class FileDeviceIdComponent : IDeviceIdComponent
+    {
+        /// <summary>
+        /// Gets the name of the component.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The paths of file we should look at
+        /// </summary>
+        private readonly string[] _paths;
+
+        /// <summary>
+        /// Should the contents of the file be hashed? relevant for sources such as /proc/cpuinfo
+        /// </summary>
+        private readonly bool _shouldHashContents;
+
+        /// <summary>
+        /// Value to use when a result is not obtainable
+        /// </summary>
+        private const string NoValue = "NoValue";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileTokenDeviceIdComponent"/> class.
+        /// </summary>
+        /// <param name="name">The name of the component.</param>
+        /// <param name="path">The path of the file holding the componentID.</param>
+        /// <param name="shouldHashContents">Whether the file contents should be hashed.</param>
+        public FileDeviceIdComponent(string name, string path, bool shouldHashContents = false) : this(name, new string[] { path }, shouldHashContents) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileTokenDeviceIdComponent"/> class.
+        /// </summary>
+        /// <param name="name">The name of the component.</param>
+        /// <param name="paths">The paths of the files holding the componentID.</param>
+        /// <param name="shouldHashContents">Whether the file contents should be hashed.</param>
+        public FileDeviceIdComponent(string name, string[] paths, bool shouldHashContents = false)
+        {
+            Name = name;
+            _paths = paths;
+            _shouldHashContents = shouldHashContents;
+        }
+
+        /// <summary>
+        /// Gets the component value.
+        /// </summary>
+        /// <returns>The component value.</returns>
+        public string GetValue()
+        {
+            foreach(string path in _paths)
+            {
+                if (!File.Exists(path))
+                    continue;
+
+                try
+                {
+                    string contents;
+
+                    using(var file = File.OpenText(path))
+                    {
+                        contents = file.ReadToEnd(); // File.ReadAllBytes() fails for special files such as /sys/class/dmi/id/product_uuid
+                    }
+                    contents = contents.Trim();
+
+                    if (!_shouldHashContents)
+                        return contents;
+                    
+                    var hasher = MD5.Create();
+                    byte[] hash = hasher.ComputeHash(ASCIIEncoding.ASCII.GetBytes(contents));
+                    return BitConverter.ToString(hash).Replace("-", "").ToUpper();   
+                }
+                catch(System.UnauthorizedAccessException){ }// can fail because we have no permissions to access the file
+
+            }
+
+            return NoValue;
+        }
+    }
+}

--- a/src/DeviceId/Components/RegistryValueDeviceIdComponent.cs
+++ b/src/DeviceId/Components/RegistryValueDeviceIdComponent.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Win32;
+
+namespace DeviceId.Components
+{
+    /// <summary>
+    /// An implementation of <see cref="IDeviceIdComponent"/> that retrieves its value from the Windows registry.
+    /// </summary>
+    public class RegistryValueDeviceIdComponent : IDeviceIdComponent
+    {
+        /// <summary>
+        /// Gets the name of the component.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The path of the registry key to look at
+        /// </summary>
+        private readonly string _key;
+
+        /// <summary>
+        /// The name of the registry value
+        /// </summary>
+        private readonly string _valueName;
+
+        /// <summary>
+        /// Value to use when a result is not obtainable
+        /// </summary>
+        private const string NoValue = "NoValue";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileTokenDeviceIdComponent"/> class.
+        /// </summary>
+        /// <param name="name">The name of the component.</param>
+        /// <param name="key">The path of the registry key to look at.</param>
+        /// <param name="valueName">the name of the registry value</param>
+        public RegistryValueDeviceIdComponent(string name, string key, string valueName)
+        {
+            Name = name;
+            _key = key;
+            _valueName = valueName;
+        }
+
+        /// <summary>
+        /// Gets the component value.
+        /// </summary>
+        /// <returns>The component value.</returns>
+        public string GetValue()
+        {
+            return Registry.GetValue(_key, _valueName, NoValue).ToString();
+        }
+    }
+}

--- a/src/DeviceId/Components/UnsupportedDeviceIdComponent.cs
+++ b/src/DeviceId/Components/UnsupportedDeviceIdComponent.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DeviceId.Components
+{
+    /// <summary>
+    /// An implementation of <see cref="IDeviceIdComponent"/> that returns a constant string to indicate this type of component is not supported
+    /// </summary>
+    class UnsupportedDeviceIdComponent : IDeviceIdComponent
+    {
+        /// <summary>
+        /// String value to use when data cannot be obtained in the current system
+        /// </summary>
+        public const string ValueUnavailable = "ValueUnavailable";
+
+        /// <summary>
+        /// Gets the name of the component.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnsupportedDeviceIdComponent"/> class.
+        /// </summary>
+        /// <param name="name">The name of the component.</param>
+        public UnsupportedDeviceIdComponent(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the component value.
+        /// </summary>
+        /// <returns>The component value.</returns>
+        public string GetValue()
+        {
+            return ValueUnavailable;
+        }
+    }
+}

--- a/src/DeviceId/DeviceId.csproj
+++ b/src/DeviceId/DeviceId.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
@@ -26,6 +27,18 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Management" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
+      <Version>3.1.3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Win32.Registry">
+      <Version>4.7.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.3.0</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds support for cross-platform, especially Linux. 
I don't have a MacOS to test this on, so I'm leaving that task to someone else :-)

The extension methods have been extended to provide different implement for each type of ID, per OS platform. 
The following ComponentIDs have been implemented for Linux:
* file /sys/class/dmi/id/board_serial using new FileDeviceIdComponent - the serial of the motherboard
* file /sys/class/dmi/id/product_uuid - the system UUID (from SMBIOS)
* Mac addresses using "native" interfaces to dotnet standard

In addition, I've added another type of component named OSInstallationID which are identities that are set when the OS is installed. There quite a few of these in Windows (MachineGuid, ActivationID, Machine account SID...) but I've chosen the MachineGuid because it's the easiest to implement. It is stored in the registry under HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid. For that a RegistryValueDeviceIdComponent has been implemented to be able to read values from the Registry. Under Linux, we read the /etc/machine-id or /var/lib/dbus/machine-id. These are set when DBUS package is installed and should be supported in all modern Linux distributions.

Please let me know what you think