### PR TITLE
Improve MMI DriveSerialNumber administrative Performance

### DIFF
--- a/src/DeviceId.Windows.Mmi/Components/MmiSystemDriveSerialNumberDeviceIdComponent.cs
+++ b/src/DeviceId.Windows.Mmi/Components/MmiSystemDriveSerialNumberDeviceIdComponent.cs
@@ -23,7 +23,7 @@ namespace DeviceId.Windows.Mmi.Components
 
             using var session = CimSession.Create(null);
 
-            foreach (var logicalDiskAssociator in session.QueryInstances(@"root\cimv2", "WQL", $"ASSOCIATORS OF {{Win32_LogicalDisk.DeviceID=\"{systemLogicalDiskDeviceId}\"}}"))
+            foreach (var logicalDiskAssociator in session.QueryInstances(@"root\cimv2", "WQL", $"ASSOCIATORS OF {{Win32_LogicalDisk.DeviceID=\"{systemLogicalDiskDeviceId}\"}} WHERE ResultClass = Win32_DiskPartition"))
             {
                 if (logicalDiskAssociator.CimClass.CimSystemProperties.ClassName == "Win32_DiskPartition")
                 {

--- a/test/DeviceId.Tests/Components/WmiAndMmiDriveSerialNumberPerfTests.cs
+++ b/test/DeviceId.Tests/Components/WmiAndMmiDriveSerialNumberPerfTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Diagnostics;
+using DeviceId.Windows.Mmi.Components;
+using DeviceId.Windows.Wmi.Components;
+using FluentAssertions;
+using Xunit;
+
+namespace DeviceId.Tests.Components
+{
+    public class WmiAndMmiDriveSerialNumberPerfTests
+    {
+        [Fact]
+        public void WmiDriveSerialNumberPerfShouldBeAcceptable()
+        {
+            var sw = Stopwatch.StartNew();
+            var deviceId = new WmiSystemDriveSerialNumberDeviceIdComponent().GetValue();
+            sw.Stop();
+
+            deviceId.Should().NotBeEmpty();
+            sw.ElapsedMilliseconds.Should().BeLessOrEqualTo(500);
+        }
+
+        [Fact]
+        public void MmiDriveSerialNumberPerfShouldBeAcceptable()
+        {
+            var sw = Stopwatch.StartNew();
+            var deviceId = new MmiSystemDriveSerialNumberDeviceIdComponent().GetValue();
+            sw.Stop();
+
+            deviceId.Should().NotBeEmpty();
+            sw.ElapsedMilliseconds.Should().BeLessOrEqualTo(500);
+        }
+    }
+}

--- a/test/DeviceId.Tests/DeviceId.Tests.csproj
+++ b/test/DeviceId.Tests/DeviceId.Tests.csproj
@@ -20,6 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\DeviceId.Windows.Mmi\DeviceId.Windows.Mmi.csproj" />
+    <ProjectReference Include="..\..\src\DeviceId.Windows.Wmi\DeviceId.Windows.Wmi.csproj" />
     <ProjectReference Include="..\..\src\DeviceId\DeviceId.csproj" />
     <ProjectReference Include="..\..\src\DeviceId.Linux\DeviceId.Linux.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #37 

Improve MMI drive SerialNumber Performance query from ~18000ms to ~150ms. This issue stems from a Microsoft.Management.Infrastructure issue where querying via "ASSOCIATORS OF" executes _very_ slowly on some machines. This issue only occurs when executing with administrative privileges. See a [related topic ](https://www.autoitscript.com/forum/topic/179441-wmi-associators-of-query-ridiculously-slower-when-running-as-administrator-than-when-running-as-a-standard-user/) about this strange behavior. I found that restricting the WQL query with `WHERE ResultClass = Win32_DiskPartition` corrects the issue.

One new test class was added which required the tests project reference two additional projects (DeviceId.Windows.Mmi and DeviceId.Windows.Wmi). If performance tests of this nature are unwanted, I'm happy to remove it. Thanks!
