### PR TITLE
Change the version of System.Management in DeviceId.Windows.Wmi project for .net stadard 2.0 target framework

### DIFF
--- a/src/DeviceId.Windows.Wmi/DeviceId.Windows.Wmi.csproj
+++ b/src/DeviceId.Windows.Wmi/DeviceId.Windows.Wmi.csproj
@@ -22,11 +22,11 @@
     <Reference Include="System.Management" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="System.Management" Version="6.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="System.Management" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Solves #73 

The .net stadard 2.0 target framework covers .net core 3.1 and .net 5.0, and System.Management 7.0 doesn't support these frameworks, which is why it makes sense to use version 6.0 for this target as the one that is supported by all it's comaptible target frameworks.