### PR TITLE
lsblk defined expected columns by using -o

### DIFF
--- a/src/DeviceId.Linux/Components/LinuxRootDriveSerialNumberDeviceIdComponent.cs
+++ b/src/DeviceId.Linux/Components/LinuxRootDriveSerialNumberDeviceIdComponent.cs
@@ -43,7 +43,7 @@ public class LinuxRootDriveSerialNumberDeviceIdComponent : IDeviceIdComponent
     /// <returns>The component value.</returns>
     public string GetValue()
     {
-        var outputJson = _commandExecutor.Execute("lsblk -f -J");
+        var outputJson = _commandExecutor.Execute("lsblk -f -J -o Name,MountPoint");
         var output = JsonSerializer.Deserialize<LsblkOutput>(outputJson, _jsonSerializerOptions);
 
         var device = FindRootParent(output);


### PR DESCRIPTION
The lsblk command since some version for json format returns the MountPoints not MountPoint. As suggested in https://github.com/util-linux/util-linux/issues/1474 we should always specify a list of the columns we want.