### PR TITLE
Add support for ARM64 processors and fix an issue on Raspberry Pi

### DIFF
--- a/src/DeviceId.Linux/LinuxDeviceIdBuilderExtensions.cs
+++ b/src/DeviceId.Linux/LinuxDeviceIdBuilderExtensions.cs
@@ -52,12 +52,18 @@ public static class LinuxDeviceIdBuilderExtensions
 
     /// <summary>
     /// Adds the product UUID (from /sys/class/dmi/id/product_uuid) to the device identifier.
+    /// On ARM systems where DMI is not available, it falls back to the Device Tree serial number.
     /// </summary>
     /// <param name="builder">The <see cref="LinuxDeviceIdBuilder"/> to add the component to.</param>
     /// <returns>The <see cref="LinuxDeviceIdBuilder"/> instance.</returns>
     public static LinuxDeviceIdBuilder AddProductUuid(this LinuxDeviceIdBuilder builder)
     {
-        return builder.AddComponent("ProductUUID", new FileContentsDeviceIdComponent("/sys/class/dmi/id/product_uuid", false));
+        return builder.AddComponent("ProductUUID", new FileContentsDeviceIdComponent(new[]
+        {
+            "/sys/class/dmi/id/product_uuid",
+            "/sys/firmware/devicetree/base/serial-number",
+            "/proc/device-tree/serial-number"
+        }, false));
     }
 
     /// <summary>
@@ -72,11 +78,47 @@ public static class LinuxDeviceIdBuilderExtensions
 
     /// <summary>
     /// Adds the motherboard serial number (from /sys/class/dmi/id/board_serial) to the device identifier.
+    /// On ARM systems where DMI is not available, it falls back to the Device Tree model.
     /// </summary>
     /// <param name="builder">The <see cref="LinuxDeviceIdBuilder"/> to add the component to.</param>
     /// <returns>The <see cref="LinuxDeviceIdBuilder"/> instance.</returns>
     public static LinuxDeviceIdBuilder AddMotherboardSerialNumber(this LinuxDeviceIdBuilder builder)
     {
-        return builder.AddComponent("MotherboardSerialNumber", new FileContentsDeviceIdComponent("/sys/class/dmi/id/board_serial", false));
+        return builder.AddComponent("MotherboardSerialNumber", new FileContentsDeviceIdComponent(new[]
+        {
+            "/sys/class/dmi/id/board_serial",
+            "/sys/firmware/devicetree/base/model",
+            "/proc/device-tree/model"
+        }, false));
+    }
+
+    /// <summary>
+    /// Adds the Device Tree serial number to the device identifier.
+    /// This is typically available on ARM-based Linux systems.
+    /// </summary>
+    /// <param name="builder">The <see cref="LinuxDeviceIdBuilder"/> to add the component to.</param>
+    /// <returns>The <see cref="LinuxDeviceIdBuilder"/> instance.</returns>
+    public static LinuxDeviceIdBuilder AddDeviceTreeSerialNumber(this LinuxDeviceIdBuilder builder)
+    {
+        return builder.AddComponent("DeviceTreeSerialNumber", new FileContentsDeviceIdComponent(new[]
+        {
+            "/sys/firmware/devicetree/base/serial-number",
+            "/proc/device-tree/serial-number"
+        }, false));
+    }
+
+    /// <summary>
+    /// Adds the Device Tree model to the device identifier.
+    /// This is typically available on ARM-based Linux systems.
+    /// </summary>
+    /// <param name="builder">The <see cref="LinuxDeviceIdBuilder"/> to add the component to.</param>
+    /// <returns>The <see cref="LinuxDeviceIdBuilder"/> instance.</returns>
+    public static LinuxDeviceIdBuilder AddDeviceTreeModel(this LinuxDeviceIdBuilder builder)
+    {
+        return builder.AddComponent("DeviceTreeModel", new FileContentsDeviceIdComponent(new[]
+        {
+            "/sys/firmware/devicetree/base/model",
+            "/proc/device-tree/model"
+        }, false));
     }
 }

--- a/src/DeviceId.Windows.Mmi/Components/MmiProcessorIdDeviceIdComponent.cs
+++ b/src/DeviceId.Windows.Mmi/Components/MmiProcessorIdDeviceIdComponent.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using Microsoft.Management.Infrastructure;
+
+namespace DeviceId.Windows.Mmi.Components;
+
+/// <summary>
+/// An implementation of <see cref="IDeviceIdComponent"/> that retrieves the processor ID using MMI.
+/// On ARM64 systems where ProcessorId is not available, it falls back to a combination of
+/// Manufacturer, Name, and NumberOfCores.
+/// </summary>
+public class MmiProcessorIdDeviceIdComponent : IDeviceIdComponent
+{
+    /// <summary>
+    /// Gets the component value.
+    /// </summary>
+    /// <returns>The component value.</returns>
+    public string GetValue()
+    {
+        var values = new List<string>();
+
+        try
+        {
+            using var session = CimSession.Create(null);
+
+            var instances = session.QueryInstances(@"root\cimv2", "WQL", "SELECT ProcessorId, Manufacturer, Name, NumberOfCores FROM Win32_Processor");
+            foreach (var instance in instances)
+            {
+                try
+                {
+                    // First try to get ProcessorId (available on x86/x64)
+                    var processorIdProperty = instance.CimInstanceProperties["ProcessorId"];
+                    if (processorIdProperty?.Value is string processorId && !string.IsNullOrEmpty(processorId))
+                    {
+                        values.Add(processorId);
+                    }
+                    else
+                    {
+                        // Fallback for ARM64: combine Manufacturer, Name, and NumberOfCores
+                        var manufacturer = instance.CimInstanceProperties["Manufacturer"]?.Value?.ToString();
+                        var name = instance.CimInstanceProperties["Name"]?.Value?.ToString();
+                        var numberOfCores = instance.CimInstanceProperties["NumberOfCores"]?.Value?.ToString();
+
+                        var fallbackParts = new List<string>();
+                        if (!string.IsNullOrEmpty(manufacturer))
+                        {
+                            fallbackParts.Add(manufacturer);
+                        }
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            fallbackParts.Add(name);
+                        }
+                        if (!string.IsNullOrEmpty(numberOfCores))
+                        {
+                            fallbackParts.Add(numberOfCores);
+                        }
+
+                        if (fallbackParts.Count > 0)
+                        {
+                            values.Add(string.Join("|", fallbackParts));
+                        }
+                    }
+                }
+                finally
+                {
+                    instance.Dispose();
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        values.Sort();
+
+        return values.Count > 0
+            ? string.Join(",", values.ToArray())
+            : null;
+    }
+}

--- a/src/DeviceId.Windows.Mmi/WindowsDeviceIdBuilderExtensions.cs
+++ b/src/DeviceId.Windows.Mmi/WindowsDeviceIdBuilderExtensions.cs
@@ -23,12 +23,14 @@ public static class WindowsDeviceIdBuilderExtensions
 
     /// <summary>
     /// Adds the processor ID to the device identifier.
+    /// On ARM64 systems where ProcessorId is not available, it falls back to a combination of
+    /// Manufacturer, Name, and NumberOfCores.
     /// </summary>
     /// <param name="builder">The <see cref="WindowsDeviceIdBuilder"/> to add the component to.</param>
     /// <returns>The <see cref="WindowsDeviceIdBuilder"/> instance.</returns>
     public static WindowsDeviceIdBuilder AddProcessorId(this WindowsDeviceIdBuilder builder)
     {
-        return builder.AddComponent("ProcessorId", new MmiWqlDeviceIdComponent("Win32_Processor", "ProcessorId"));
+        return builder.AddComponent("ProcessorId", new MmiProcessorIdDeviceIdComponent());
     }
 
     /// <summary>

--- a/src/DeviceId.Windows.Wmi/Components/WmiProcessorIdDeviceIdComponent.cs
+++ b/src/DeviceId.Windows.Wmi/Components/WmiProcessorIdDeviceIdComponent.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Management;
+
+namespace DeviceId.Windows.Wmi.Components;
+
+/// <summary>
+/// An implementation of <see cref="IDeviceIdComponent"/> that retrieves the processor ID.
+/// On ARM64 systems where ProcessorId is not available, it falls back to a combination of
+/// Manufacturer, Name, and NumberOfCores.
+/// </summary>
+public class WmiProcessorIdDeviceIdComponent : IDeviceIdComponent
+{
+    /// <summary>
+    /// Gets the component value.
+    /// </summary>
+    /// <returns>The component value.</returns>
+    public string GetValue()
+    {
+        var values = new List<string>();
+
+        try
+        {
+            using var managementObjectSearcher = new ManagementObjectSearcher("SELECT ProcessorId, Manufacturer, Name, NumberOfCores FROM Win32_Processor");
+            using var managementObjectCollection = managementObjectSearcher.Get();
+            foreach (var managementObject in managementObjectCollection)
+            {
+                try
+                {
+                    // First try to get ProcessorId (available on x86/x64)
+                    if (managementObject["ProcessorId"] is string processorId && !string.IsNullOrEmpty(processorId))
+                    {
+                        values.Add(processorId);
+                    }
+                    else
+                    {
+                        // Fallback for ARM64: combine Manufacturer, Name, and NumberOfCores
+                        var manufacturer = managementObject["Manufacturer"]?.ToString();
+                        var name = managementObject["Name"]?.ToString();
+                        var numberOfCores = managementObject["NumberOfCores"]?.ToString();
+
+                        var fallbackParts = new List<string>();
+                        if (!string.IsNullOrEmpty(manufacturer))
+                        {
+                            fallbackParts.Add(manufacturer);
+                        }
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            fallbackParts.Add(name);
+                        }
+                        if (!string.IsNullOrEmpty(numberOfCores))
+                        {
+                            fallbackParts.Add(numberOfCores);
+                        }
+
+                        if (fallbackParts.Count > 0)
+                        {
+                            values.Add(string.Join("|", fallbackParts));
+                        }
+                    }
+                }
+                finally
+                {
+                    managementObject.Dispose();
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        values.Sort();
+
+        return values.Count > 0
+            ? string.Join(",", values.ToArray())
+            : null;
+    }
+}

--- a/src/DeviceId.Windows.Wmi/WindowsDeviceIdBuilderExtensions.cs
+++ b/src/DeviceId.Windows.Wmi/WindowsDeviceIdBuilderExtensions.cs
@@ -23,12 +23,14 @@ public static class WindowsDeviceIdBuilderExtensions
 
     /// <summary>
     /// Adds the processor ID to the device identifier.
+    /// On ARM64 systems where ProcessorId is not available, it falls back to a combination of
+    /// Manufacturer, Name, and NumberOfCores.
     /// </summary>
     /// <param name="builder">The <see cref="WindowsDeviceIdBuilder"/> to add the component to.</param>
     /// <returns>The <see cref="WindowsDeviceIdBuilder"/> instance.</returns>
     public static WindowsDeviceIdBuilder AddProcessorId(this WindowsDeviceIdBuilder builder)
     {
-        return builder.AddComponent("ProcessorId", new WmiDeviceIdComponent("Win32_Processor", "ProcessorId"));
+        return builder.AddComponent("ProcessorId", new WmiProcessorIdDeviceIdComponent());
     }
 
     /// <summary>

--- a/src/DeviceId.Windows.WmiLight/Components/WmiLightProcessorIdDeviceIdComponent.cs
+++ b/src/DeviceId.Windows.WmiLight/Components/WmiLightProcessorIdDeviceIdComponent.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using WmiLight;
+
+namespace DeviceId.Windows.WmiLight.Components;
+
+/// <summary>
+/// An implementation of <see cref="IDeviceIdComponent"/> that retrieves the processor ID using WmiLight.
+/// On ARM64 systems where ProcessorId is not available, it falls back to a combination of
+/// Manufacturer, Name, and NumberOfCores.
+/// </summary>
+public class WmiLightProcessorIdDeviceIdComponent : IDeviceIdComponent
+{
+    /// <summary>
+    /// Gets the component value.
+    /// </summary>
+    /// <returns>The component value.</returns>
+    public string GetValue()
+    {
+        var values = new List<string>();
+
+        try
+        {
+            using var wmiConnection = new WmiConnection();
+            foreach (var wmiObject in wmiConnection.CreateQuery("SELECT * FROM Win32_Processor"))
+            {
+                try
+                {
+                    // First try to get ProcessorId (available on x86/x64)
+                    if (wmiObject["ProcessorId"] is string processorId && !string.IsNullOrEmpty(processorId))
+                    {
+                        values.Add(processorId);
+                    }
+                    else
+                    {
+                        // Fallback for ARM64: combine Manufacturer, Name, and NumberOfCores
+                        var manufacturer = wmiObject["Manufacturer"]?.ToString();
+                        var name = wmiObject["Name"]?.ToString();
+                        var numberOfCores = wmiObject["NumberOfCores"]?.ToString();
+
+                        var fallbackParts = new List<string>();
+                        if (!string.IsNullOrEmpty(manufacturer))
+                        {
+                            fallbackParts.Add(manufacturer);
+                        }
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            fallbackParts.Add(name);
+                        }
+                        if (!string.IsNullOrEmpty(numberOfCores))
+                        {
+                            fallbackParts.Add(numberOfCores);
+                        }
+
+                        if (fallbackParts.Count > 0)
+                        {
+                            values.Add(string.Join("|", fallbackParts));
+                        }
+                    }
+                }
+                finally
+                {
+                    wmiObject.Dispose();
+                }
+            }
+        }
+        catch
+        {
+            // Ignore exceptions
+        }
+
+        values.Sort();
+
+        return values.Count > 0
+            ? string.Join(",", values.ToArray())
+            : null;
+    }
+}

--- a/src/DeviceId.Windows.WmiLight/WindowsDeviceIdBuilderExtensions.cs
+++ b/src/DeviceId.Windows.WmiLight/WindowsDeviceIdBuilderExtensions.cs
@@ -24,12 +24,14 @@ public static class WindowsDeviceIdBuilderExtensions
 
     /// <summary>
     /// Adds the processor ID to the device identifier.
+    /// On ARM64 systems where ProcessorId is not available, it falls back to a combination of
+    /// Manufacturer, Name, and NumberOfCores.
     /// </summary>
     /// <param name="builder">The <see cref="WindowsDeviceIdBuilder"/> to add the component to.</param>
     /// <returns>The <see cref="WindowsDeviceIdBuilder"/> instance.</returns>
     public static WindowsDeviceIdBuilder AddProcessorId(this WindowsDeviceIdBuilder builder)
     {
-        return builder.AddComponent("ProcessorId", new WmiLightDeviceIdComponent("Win32_Processor", "ProcessorId"));
+        return builder.AddComponent("ProcessorId", new WmiLightProcessorIdDeviceIdComponent());
     }
 
     /// <summary>

--- a/src/DeviceId/Components/FileContentsDeviceIdComponent.cs
+++ b/src/DeviceId/Components/FileContentsDeviceIdComponent.cs
@@ -63,7 +63,7 @@ public class FileContentsDeviceIdComponent : IDeviceIdComponent
                     contents = file.ReadToEnd(); // File.ReadAllBytes() fails for special files such as /sys/class/dmi/id/product_uuid
                 }
 
-                contents = contents.Trim();
+                contents = contents.Trim((char)0).Trim();
 
                 if (!_hashContents)
                 {


### PR DESCRIPTION
This PR pulls in changes from https://github.com/laikee99/DeviceId/commit/b0afa7bb5fb57a78fb50e02e5bbac766bfc928c4 to provide ARM64 support (Windows and Linux). Plus a fix where the model data read on Raspberry Pi includes a nul-term character so I've added a trim for that.